### PR TITLE
Update AMPDockerFileJava

### DIFF
--- a/AMPDockerFileJava
+++ b/AMPDockerFileJava
@@ -8,12 +8,10 @@ RUN mkdir -p /usr/share/man/man1 && \
     wget -qO- https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor > /usr/share/keyrings/adoptium.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb bullseye main" > /etc/apt/sources.list.d/adoptium.list && \
     apt-get update && \
-    apt-get install -y temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-18-jdk && \
+    apt-get install -y temurin-8-jdk temurin-11-jdk temurin-17-jdk temurin-18-jdk temurin-21-jdk && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i 's#mozilla/DST_Root_CA_X3.crt#!mozilla/DST_Root_CA_X3.crt#' /etc/ca-certificates.conf && update-ca-certificates
-
-ADD ampstart.sh /
 
 ENTRYPOINT ["/ampstart.sh"]
 CMD []


### PR DESCRIPTION
Add Java 21 LTS to image and remove ADD ampstart.sh / to stop the conflict that the panel was having when switching from one docker container to another.