### PR TITLE
Create AMPDockerFilepython312

### DIFF
--- a/AMPDockerFilepython312
+++ b/AMPDockerFilepython312
@@ -1,0 +1,14 @@
+FROM cubecoders/ampbase
+
+RUN cd /tmp/ \
+    && wget https://www.python.org/ftp/python/3.12.1/Python-3.12.1.tgz \
+    && tar -xvf Python-3.12.1.tgz \
+    && cd Python-3.12.1 \
+    && apt update \
+    && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget python3-pip \
+    && ./configure --enable-optimizations \
+    && make -j 4 \
+    && make altinstall
+
+ENTRYPOINT ["/ampstart.sh"]
+CMD []


### PR DESCRIPTION
Build of Python 3.12 to the CubeCoders AMPBase Docker Container Image. This is built from Python Site and does have pip installed as well. Is backwards compatible with other versions of python.