### PR TITLE
Create AMPDockerFilePython312

### DIFF
--- a/AMPDockerFilepython312
+++ b/AMPDockerFilepython312
@@ -1,0 +1,14 @@
+FROM cubecoders/ampbase
+
+RUN cd /tmp/ \
+    && wget https://www.python.org/ftp/python/3.12.1/Python-3.12.1.tgz \
+    && tar -xvf Python-3.12.1.tgz \
+    && cd Python-3.12.1 \
+    && apt update \
+    && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget python3-pip python3.11-venv \
+    && ./configure --enable-optimizations \
+    && make -j 4 \
+    && make altinstall
+
+ENTRYPOINT ["/ampstart.sh"]
+CMD []


### PR DESCRIPTION
Python 3.12.1 build with Python 3.11 pip and venv backwards support for older templates. Working image at ssfdre38/ampdocker:python312 ( https://hub.docker.com/r/ssfdre38/ampdocker )